### PR TITLE
Fixed case issue

### DIFF
--- a/src/app/document-view/document-view.directive.ts
+++ b/src/app/document-view/document-view.directive.ts
@@ -9,7 +9,7 @@ import {
 } from '@angular/core';
 import { ViewProviders } from './models/ViewProviders';
 import { UriBuilder } from 'uribuilder';
-import { cleanPath } from 'cleanPath';
+import { cleanPath } from 'cleanpath';
 import { Observable } from 'rxjs/Observable';
 import { TimerObservable } from 'rxjs/observable/TimerObservable';
 import 'rxjs/operator/toPromise';


### PR DESCRIPTION
`cleanpath` is all lowercase, so current released module works only with case-insensitive file systems. 